### PR TITLE
[codex] Refactor Playwright tests around shared login fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+.playwright-cli/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,16 +41,6 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
     /* Test against mobile viewports. */
     // {
     //   name: 'Mobile Chrome',

--- a/tests/accessibility.test.ts
+++ b/tests/accessibility.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { gotoOpencartOrSkip } from './helpers/opencart';
 
-test('Accessibility Test', async ({ page }) => {
+test('@accessibility - Accessibility Test', async ({ page }) => {
   await gotoOpencartOrSkip(
     page,
     'https://naveenautomationlabs.com/opencart/index.php?route=account/register'

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,8 +1,8 @@
 import {test, expect, Browser, Page, BrowserContext} from '@playwright/test';
-import {chromium, firefox, webkit} from 'playwright';
+import {chromium} from 'playwright';
 
 test('auth test', async() =>  {
-    const browser: Browser = await webkit.launch({headless:true});
+    const browser: Browser = await chromium.launch({headless:true});
     const browserContext: BrowserContext = await browser.newContext();
 
     const uname = 'admin';

--- a/tests/fixtures/heroku-login.ts
+++ b/tests/fixtures/heroku-login.ts
@@ -1,0 +1,36 @@
+import { test as base, expect, type Locator } from '@playwright/test';
+
+const HEROKU_LOGIN_URL = 'https://the-internet.herokuapp.com/login';
+
+type HerokuLoginPage = {
+  goto(): Promise<void>;
+  loginAs(username: string, password: string): Promise<void>;
+  usernameInput: Locator;
+  passwordInput: Locator;
+  loginButton: Locator;
+  flashMessage: Locator;
+};
+
+export const test = base.extend<{ herokuLoginPage: HerokuLoginPage }>({
+  herokuLoginPage: async ({ page }, use) => {
+    const herokuLoginPage: HerokuLoginPage = {
+      async goto() {
+        await page.goto(HEROKU_LOGIN_URL, { waitUntil: 'domcontentloaded' });
+        await expect(page.getByRole('heading', { name: 'Login Page' })).toBeVisible();
+      },
+      async loginAs(username: string, password: string) {
+        await herokuLoginPage.usernameInput.fill(username);
+        await herokuLoginPage.passwordInput.fill(password);
+        await herokuLoginPage.loginButton.click();
+      },
+      usernameInput: page.getByLabel('Username'),
+      passwordInput: page.getByLabel('Password'),
+      loginButton: page.getByRole('button', { name: /Login/ }),
+      flashMessage: page.locator('#flash'),
+    };
+
+    await use(herokuLoginPage);
+  },
+});
+
+export { expect };

--- a/tests/google.spec.ts
+++ b/tests/google.spec.ts
@@ -1,0 +1,13 @@
+import {expect, test, Page} from '@playwright/test';
+import { chromium, type Browser } from 'playwright';
+
+test('@google - Google Images Searcg Test', async( { } ) => {
+    const browser: Browser = await chromium.launch({headless:true});
+    const context = await browser.newContext();
+    const page1: Page = await context.newPage();
+    await page1.goto('https://www.google.com/');
+    const imageLink = page1.locator("[aria-label='Search for Images ']");
+    await imageLink.click();
+    await expect(page1.url()).toContain('https://www.google.com/imghp?hl=en&ogbl');
+    await page1.waitForTimeout(1500);
+    });

--- a/tests/invalid-login-shows-error.spec.ts
+++ b/tests/invalid-login-shows-error.spec.ts
@@ -1,23 +1,12 @@
 // spec: Navigate to https://the-internet.herokuapp.com/login and validate invalid login error message
 // seed: tests/seed.spec.ts
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/heroku-login';
 
 test.describe('Navigate to https://the-internet.herokuapp.com/login and validate invalid login error message', () => {
-  test('Invalid Login Shows Error', async ({ page }) => {
-    // Navigate to the login page
-    await page.goto('https://the-internet.herokuapp.com/login');
-
-    // Enter the username as 'admin'
-    await page.getByLabel('Username').fill('admin');
-
-    // Enter the password as 'admin'
-    await page.getByLabel('Password').fill('admin');
-
-    // Click Login button
-    await page.getByRole('button', { name: /Login/ }).click();
-
-    // Validate we see error message 'Your username is invalid!'
-    await expect(page.getByText('Your username is invalid!')).toBeVisible();
+  test('Invalid Login Shows Error', async ({ herokuLoginPage }) => {
+    await herokuLoginPage.goto();
+    await herokuLoginPage.loginAs('admin', 'admin');
+    await expect(herokuLoginPage.flashMessage).toContainText('Your username is invalid!');
   });
 });

--- a/tests/locator.chaining.test.ts
+++ b/tests/locator.chaining.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { gotoOpencartOrSkip } from './helpers/opencart';
 
-test('locator chaining test', async ({ page }) => {
+test('@locatorchaining - Locator Chaining Test', async ({ page }) => {
   await gotoOpencartOrSkip(
     page,
     'https://naveenautomationlabs.com/opencart/index.php?route=account/register'

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,5 +1,5 @@
-// Import necessary modules from @playwright/test
-import { test, expect } from '@playwright/test';
+// Import necessary modules from fixture-aware test wrapper
+import { test, expect } from './fixtures/heroku-login';
 // Import helper function to navigate OpenCart or skip it if not needed
 import { gotoOpencartOrSkip } from './helpers/opencart';
 
@@ -41,10 +41,8 @@ test.skip(
 /**
  * Test that the Herokuapp login page accepts username input.
  */
-test('herokuapp login page accepts username input', async ({ page }) => {
-  await page.goto('https://the-internet.herokuapp.com/login', { waitUntil: 'domcontentloaded' });
-
-  const username = page.locator('#username');
-  await username.fill('clydesdale');
-  await expect(username).toHaveValue('clydesdale');
+test('herokuapp login page accepts username input', async ({ herokuLoginPage }) => {
+  await herokuLoginPage.goto();
+  await herokuLoginPage.usernameInput.fill('clydesdale');
+  await expect(herokuLoginPage.usernameInput).toHaveValue('clydesdale');
 });


### PR DESCRIPTION
## Summary
- add a reusable Heroku login fixture and update the Heroku login specs to use it
- tag selected tests, add the Google images spec, and clean up browser-specific test usage
- limit the configured projects to Chromium and ignore the local Playwright CLI cache directory

## Testing
- `npx playwright test tests/login.spec.ts tests/invalid-login-shows-error.spec.ts tests/auth.spec.ts tests/accessibility.test.ts tests/locator.chaining.test.ts tests/google.spec.ts --project=chromium`
- blocked in this environment because Chromium fails to launch under the macOS sandbox with `MachPortRendezvous` permission errors before assertions run