### PR TITLE
[codex] Add Binaryville login page object test

### DIFF
--- a/tests/POM/login.page.pom.ts
+++ b/tests/POM/login.page.pom.ts
@@ -1,0 +1,20 @@
+import {Locator, Page } from '@playwright/test';
+
+export class LoginPage{
+    public readonly emailId: Locator;
+    public readonly password: Locator;
+    public readonly loginButton: Locator;
+
+    constructor(page: Page){
+        this.emailId = page.getByRole('textbox', { name: 'Email' });
+        this.password = page.getByRole('textbox', { name: 'Password' });
+        this.loginButton = page.getByRole('button', { name: 'Sign in' });
+    }
+
+    async login(email: string, password: string){
+        await this.emailId.fill(email);
+        await this.password.fill(password);
+        await this.loginButton.click();
+    }
+
+}

--- a/tests/login.test.ts
+++ b/tests/login.test.ts
@@ -1,0 +1,14 @@
+import { expect, test as base } from '@playwright/test';
+import { LoginPage } from './POM/login.page.pom';
+
+const test = base.extend<{ loginPage: LoginPage }>({
+    loginPage: async ({ page }, use) => {
+        await page.goto('https://binaryville.com/account/');
+        await use(new LoginPage(page));
+    },
+});
+
+test('@login - Login Test', async ({ loginPage, page }) => {
+    await loginPage.login('happy_gilmore@gmail.com', 'Happy@123');
+    await expect(page).toHaveURL('https://binaryville.com/account/?email=happy_gilmore%40gmail.com&password=Happy%40123#');
+});


### PR DESCRIPTION
## What changed
- added a `LoginPage` page object for the Binaryville account login form
- added a Playwright test that uses the page object to attempt a login flow

## Why
- adds an example of a page-object-based Playwright test against the Binaryville login page

## Impact
- introduces new test coverage under `tests/`
- no production code changes

## Validation
- `npx playwright test tests/login.test.ts --project=chromium`
- blocked locally by the sandboxed environment: Chromium failed to launch with a macOS permission error before the test body executed