### PR TITLE
Add Playwright homepage link checks

### DIFF
--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -10,9 +10,27 @@ test('has title', async ({ page }) => {
 test('get started link', async ({ page }) => {
   await page.goto('https://playwright.dev/');
 
+  await expect(page.getByRole('link', { name: 'Docs', exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'MCP', exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'CLI', exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'API', exact: true })).toBeVisible();
+
   // Click the get started link.
   await page.getByRole('link', { name: 'Get started' }).click();
 
   // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+});
+
+test('get started button is present and clickable', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  const getStarted = page.getByRole('link', { name: 'Get started' });
+
+  await expect(getStarted).toBeVisible();
+  await expect(getStarted).toBeEnabled();
+
+  await getStarted.click();
+
   await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- verify Docs, MCP, CLI, and API links in the existing Playwright homepage test
- add a separate check that the Get started control is visible, enabled, and clickable

## Tests
- npx playwright test tests/example.spec.ts --project=chromium