### PR TITLE
[codex] Update Playwright TypeScript config

### DIFF
--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -23,7 +23,12 @@ test('opencart login page loads', async ({ page }) => {
  */
 test.skip(
   'opencart login succeeds',
-  'Temporarily skipped: external site/account state is unstable',
+  {
+    annotation: {
+      type: 'skip',
+      description: 'Temporarily skipped: external site/account state is unstable',
+    },
+  },
   async ({ page }) => {
     await gotoOpencartOrSkip(page, OPENCART_LOGIN_URL);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,50 +1,17 @@
 {
-  // Visit https://aka.ms/tsconfig to read more about this file
-  "ts-node": {
-    "compilerOptions": {
-      "module": "commonjs",
-      "verbatimModuleSyntax": false
-    }
-  },
   "compilerOptions": {
-    // File Layout
-    // "rootDir": "./src",
-    // "outDir": "./dist",
-
-    // Environment Settings
-    // See also https://aka.ms/tsconfig/module
-    "module": "nodenext", 
-    "target": "ES6",
-    "types": [],
-    // For nodejs:
-    // "lib": ["esnext"],
-    // "types": ["node"],
-    // and npm install -D @types/node
-
-    // Other Outputs
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-
-    // Stricter Typechecking Options
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-
-    // Style Options
-    // "noImplicitReturns": true,
-    // "noImplicitOverride": true,
-    // "noUnusedLocals": true,
-    // "noUnusedParameters": true,
-    // "noFallthroughCasesInSwitch": true,
-    // "noPropertyAccessFromIndexSignature": true,
-
-    // Recommended Options
+    "target": "ESNext",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "strict": true,
-    "jsx": "react-jsx",
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "noUncheckedSideEffectImports": true,
-    "moduleDetection": "force",
-    "skipLibCheck": true
-  }
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": [
+    "playwright.config.ts",
+    "playwright.config.dev.ts",
+    "tests/**/*.ts"
+  ]
 }


### PR DESCRIPTION
Closed because this change was opened against the wrong repository. The corrected PR should target `cdclydesdale/typescriptdemo`.